### PR TITLE
Fixes issue #8 - gcc catch by value and implicit fallthrough warnings

### DIFF
--- a/pegasus/src/Clients/cimcli/CIMCLICommand.cpp
+++ b/pegasus/src/Clients/cimcli/CIMCLICommand.cpp
@@ -227,7 +227,7 @@ public:
         // FUTURE - Should test against operation we are expecting
         if (_localVerboseTest &&
             ((item.operationType <= 0) || item.operationType >
-                CIM_ENUMERATION_COUNT_REQUEST_MESSAGE))
+                (CIMOperationType)CIM_ENUMERATION_COUNT_REQUEST_MESSAGE))
         {
            cerr << "Error:Operation type " << item.operationType
                 << " out of expected range in ClientOpPerformanceData"

--- a/pegasus/src/Clients/cimcli/ObjectBuilder.cpp
+++ b/pegasus/src/Clients/cimcli/ObjectBuilder.cpp
@@ -1131,6 +1131,7 @@ void ObjectBuilder::scanInputList(CIMClient& client,
                 //#P 33
                 //#T PARSE_FAIL_ERR
                 //#S Parse Failed. Input Parameter \"{0}\".
+                break;  // added to avoid compiler warning message
             }
 
         case UNKNOWN:

--- a/pegasus/src/Clients/osinfo/OSInfo.cpp
+++ b/pegasus/src/Clients/osinfo/OSInfo.cpp
@@ -841,7 +841,7 @@ void OSInfoCommand::gatherProperties(CIMInstance &inst, Boolean cimFormat)
       else if (propertyName.equal (CIMName ("SystemUpTime")))
       {
          Uint64 total;
-         char   uptime[80];
+         char   uptime[160];
          inst.getProperty(j).getValue().get(total);
 
          if (!cimFormat)
@@ -872,7 +872,7 @@ void OSInfoCommand::gatherProperties(CIMInstance &inst, Boolean cimFormat)
             }
             else
             {
-                sprintf(dayString, (days == 1 ? 
+                sprintf(dayString, (days == 1 ?
                     "%" PEGASUS_64BIT_CONVERSION_WIDTH "u day," :
                     "%" PEGASUS_64BIT_CONVERSION_WIDTH "u days," ), days);
 

--- a/pegasus/src/Clients/wbemexec/XMLProcess.cpp
+++ b/pegasus/src/Clients/wbemexec/XMLProcess.cpp
@@ -85,8 +85,6 @@ Buffer XMLProcess::encapsulate( XmlParser& parser,
                                        Buffer& content,
                                        Buffer& httpHeaders
                                        )
-throw (XmlValidationError, XmlSemanticError, WbemExecException,
-               XmlException, Exception)
 {
     XmlEntry                     entry;
     Buffer                    message;

--- a/pegasus/src/Clients/wbemexec/XMLProcess.h
+++ b/pegasus/src/Clients/wbemexec/XMLProcess.h
@@ -96,9 +96,7 @@ public:
         Boolean useMPost,
         Boolean useHTTP11,
         Buffer& content,
-        Buffer& httpHeaders)
-        throw (XmlValidationError, XmlSemanticError, WbemExecException,
-               XmlException, Exception);
+        Buffer& httpHeaders);
 };
 
 PEGASUS_NAMESPACE_END

--- a/pegasus/src/Pegasus/CQL/CQLCLI/CQLCLI.cpp
+++ b/pegasus/src/Pegasus/CQL/CQLCLI/CQLCLI.cpp
@@ -511,7 +511,7 @@ Boolean _evaluate(Array<CQLSelectStatement>& _statements,
                   else
                        cout << "FALSE" << endl;
                 }
-                catch(Exception e)
+                catch(const Exception& e)
                 {
                   if (cqlcli_verbose)
                     cout << "ERROR! -- " << _statements[i].toString() << endl
@@ -1158,7 +1158,7 @@ int main(int argc, char ** argv)
                 _evaluate(_statements,_instances, testOption);
                 _normalize(_statements,_instances, testOption);
             }
-            catch(Exception e)
+            catch(const Exception& e)
             {
                 cout << getStatementString(e.getMessage()) << endl;
             }
@@ -1177,4 +1177,3 @@ int main(int argc, char ** argv)
      //
     return 0;
 }
-

--- a/pegasus/src/Pegasus/CQL/CQLFunctionRep.cpp
+++ b/pegasus/src/Pegasus/CQL/CQLFunctionRep.cpp
@@ -304,7 +304,10 @@ String CQLFunctionRep::functionTypeToString() const
             break;
         case UNKNOWN:
             returnStr.append("UNKNOWN");
+            break;
         default:
+            /* TODO/ks/15Oct20: This and the above append UNKNOWN.  Should this
+               append something else to avoid confusion. */
             returnStr.append("UNKNOWN");
             break;
     }

--- a/pegasus/src/Pegasus/CQL/tests/CQLValue/CQLValue.cpp
+++ b/pegasus/src/Pegasus/CQL/tests/CQLValue/CQLValue.cpp
@@ -651,11 +651,10 @@ int main( int argc, char *argv[] ){
     cout << argv[0] << " " << argv[1] << " +++++ passed all tests" << endl;
 
     }
-    catch(Exception e)
+    catch(const Exception& e)
     {
         cout << e.getMessage() << endl;
         PEGASUS_TEST_ASSERT(0);
     }
     return 0;
 }
-

--- a/pegasus/src/Pegasus/Client/CIMOperationRequestEncoder.cpp
+++ b/pegasus/src/Pegasus/Client/CIMOperationRequestEncoder.cpp
@@ -533,15 +533,15 @@ void CIMOperationRequestEncoder::_encodeGetInstanceRequest(
         XmlWriter::appendPropertyListIParameter(
             params, message->propertyList);
 
-        Buffer buffer = XmlWriter::formatSimpleIMethodReqMessage(_hostName,
-        message->nameSpace, CIMName ("GetInstance"), message->messageId,
-        message->getHttpMethod(),
-        _authenticator->buildRequestAuthHeader(),
-        ((AcceptLanguageListContainer)message->operationContext.get(
-            AcceptLanguageListContainer::NAME)).getLanguages(),
-        ((ContentLanguageListContainer)message->operationContext.get(
-            ContentLanguageListContainer::NAME)).getLanguages(),
-        params, _binaryResponse);
+    Buffer buffer = XmlWriter::formatSimpleIMethodReqMessage(_hostName,
+    message->nameSpace, CIMName ("GetInstance"), message->messageId,
+    message->getHttpMethod(),
+    _authenticator->buildRequestAuthHeader(),
+    ((AcceptLanguageListContainer)message->operationContext.get(
+        AcceptLanguageListContainer::NAME)).getLanguages(),
+    ((ContentLanguageListContainer)message->operationContext.get(
+        ContentLanguageListContainer::NAME)).getLanguages(),
+    params, _binaryResponse);
 
     _sendRequest(buffer);
 }

--- a/pegasus/src/Pegasus/Client/tests/PullErrors/PullErrors.cpp
+++ b/pegasus/src/Pegasus/Client/tests/PullErrors/PullErrors.cpp
@@ -102,7 +102,7 @@ static Boolean verbose;
  *    [-charSet]    set matches a literal hypen and any character in the set
  *    []charSet]    match a literal close bracket and any character in the set
  *
- *    char          match itself except where char is '*' or '?' or '['
+ *    char          match itself except where char is '*', '?', '[', or '\'
  *    \char         match char, including any pattern character
  *
  * examples:
@@ -261,6 +261,8 @@ bool _globMatch(const char* pattern, const char* str)
                 {
                     patChar = *pattern++;
                 }
+                // TODO'ks'15Oct20: validate this fallthrough with test
+                /*FALLTHROUGH*/
             // default, test current character
             default:
                 if (patChar != *str)
@@ -279,61 +281,6 @@ static int _globMatch(const String& pattern, const String& str)
     return _globMatch(pattern.getCString(), str.getCString());
 }
 
-////// Original match.  However, this one appears to have problems
-////static int _match(const char* pattern, const char* str)
-////{
-////    const char* p;
-////    const char* q;
-////
-////    /* Now match expression to str. */
-////
-////    for (p = pattern, q = str; *p && *q; )
-////    {
-////        if (*p == '*')
-////        {
-////            const char* r;
-////
-////            p++;
-////
-////            /* Recursively call to find the shortest match. */
-////
-////            for (r = q; *r; r++)
-////            {
-////                if (_match(p, r) == 0)
-////                    break;
-////            }
-////
-////            q = r;
-////
-////        }
-////        else if (*p == *q)
-////        {
-////            p++;
-////            q++;
-////        }
-////        else
-////            return -1;
-////    }
-////
-////    /* If src was exhausted but pattern has a single '*'remaining charcters,
-////     * then match the result.
-////     */
-////
-////    if (p[0] == '*' && p[1] == '\0')
-////        return 0;
-////
-////    /* If anything left over, then they do not match. */
-////
-////    if (*p || *q)
-////        return -1;
-////
-////    return 0;
-////}
-////
-////static int _Match(const String& pattern, const String& str)
-////{
-////    return _match(pattern.getCString(), str.getCString());
-////}
 
 /***************************************************************************
     Class to test all of the different operations with various

--- a/pegasus/src/Pegasus/Client/tests/TestStaticClient/TestStaticClient.cpp
+++ b/pegasus/src/Pegasus/Client/tests/TestStaticClient/TestStaticClient.cpp
@@ -83,7 +83,7 @@ int main()
     {
         cout << "\n+++++ passed all tests" << endl;
     }
-    catch(Exception)
+    catch(Exception&)
     {
         cout << "\n----- Test Static Client Failed" << endl;
     }

--- a/pegasus/src/Pegasus/Common/CIMResponseData.cpp
+++ b/pegasus/src/Pegasus/Common/CIMResponseData.cpp
@@ -979,7 +979,7 @@ void CIMResponseData::completeHostNameAndNamespace(
         {
             // Instances added to account for namedInstance in Pull operations.
             case RESP_INSTANCES:
-
+            {
                 for (Uint32 j = 0, n = _instances.size(); j < n; j++)
                 {
                     const CIMInstance& instance = _instances[j];
@@ -994,6 +994,9 @@ void CIMResponseData::completeHostNameAndNamespace(
                         p.setNameSpace(ns);
                     }
                 }
+            }
+            break;
+
             case RESP_OBJECTS:
             {
                 for (Uint32 j = 0, n = _objects.size(); j < n; j++)

--- a/pegasus/src/Pegasus/Common/InternalException.cpp
+++ b/pegasus/src/Pegasus/Common/InternalException.cpp
@@ -982,7 +982,7 @@ SocketWriteError::~SocketWriteError()
 //     PEGASUS_MAXELEMENTS_NUM HTTP header fields in a single HTTP message
 //==============================================================================
 TooManyHTTPHeadersException::TooManyHTTPHeadersException()
-    : Exception("more than "PEGASUS_MAXELEMENTS
+    : Exception("more than " PEGASUS_MAXELEMENTS
                     " header fields detected in HTTP message")
 {
 }

--- a/pegasus/src/Pegasus/Common/Logger.cpp
+++ b/pegasus/src/Pegasus/Common/Logger.cpp
@@ -500,12 +500,16 @@ void Logger::setlogLevelMask( const String &logLevelList )
         {
             case Logger::TRACE:
                   _severityMask |= Logger::TRACE;
+                  /* FALLTHROUGH */
             case Logger::INFORMATION:
                   _severityMask |= Logger::INFORMATION;
+                  /* FALLTHROUGH */
             case Logger::WARNING:
                   _severityMask |= Logger::WARNING;
+                  /* FALLTHROUGH */
             case Logger::SEVERE:
                   _severityMask |= Logger::SEVERE;
+                  /* FALLTHROUGH */
             case Logger::FATAL:
                   _severityMask |= Logger::FATAL;
         }

--- a/pegasus/src/Pegasus/ControlProviders/InteropProvider/InteropProvider.cpp
+++ b/pegasus/src/Pegasus/ControlProviders/InteropProvider/InteropProvider.cpp
@@ -804,6 +804,7 @@ bool InteropProvider::validAssocClassForObject(
               expectedTargetRole = PROPERTY_ANTECEDENT;
               expectedOriginRole = PROPERTY_DEPENDENT;
           }
+          break;
       case PG_HOSTEDOBJECTMANAGER:
           if(originClassEnum == PG_COMPUTERSYSTEM)
           {

--- a/pegasus/src/Pegasus/ControlProviders/QueryCapabilitiesProvider/tests/TestCIMQueryCap.cpp
+++ b/pegasus/src/Pegasus/ControlProviders/QueryCapabilitiesProvider/tests/TestCIMQueryCap.cpp
@@ -195,7 +195,7 @@ void testCreateInstance(CIMClient& client, const char* ns)
   {
     path = client.createInstance(ns, instances[0]);
   }
-  catch(Exception)
+  catch(const Exception&)
   {
     // Do nothing. This is expected since createInstance is NOT
     // supported.
@@ -216,7 +216,7 @@ void testDeleteInstance(CIMClient& client, const char* ns)
   {
     client.deleteInstance(ns, instances[0].getPath());
   }
-  catch(Exception)
+  catch(const Exception&)
   {
     // Do nothing. This is expected since deleteInstance is NOT
     // supported.
@@ -246,7 +246,7 @@ void testModifyInstance(CIMClient& client, const char* ns)
   {
     client.modifyInstance(ns, instances[0]);
   }
-  catch(Exception)
+  catch(const Exception&)
   {
     // Do nothing. This is expected since modifyInstance is NOT
     // supported.
@@ -268,7 +268,7 @@ int main(int, char** argv)
    {
      client.connectLocal();
    }
-   catch (Exception& e)
+   catch (const Exception& e)
    {
       cerr << "Error: " << e.getMessage() <<  endl;
       cerr << "Exception occured while trying to connect to the server."
@@ -304,7 +304,7 @@ int main(int, char** argv)
      testModifyInstance(client, NAMESPACE_CIMV2);
      testModifyInstance(client, NAMESPACE_SAMPLEPROVIDER);
    }
-   catch(Exception& e)
+   catch(const Exception& e)
    {
       cerr << argv[0] << ": Exception Occcured. " << e.getMessage() << endl;
       cerr << argv[0] << ": " << testCaseName << " Failed. " << endl;
@@ -314,5 +314,3 @@ int main(int, char** argv)
    cout << argv[0] << " +++++ passed all tests" << endl;
    return 0;
 }
-
-

--- a/pegasus/src/Pegasus/DynListener/tests/TestDynListener/TestListener.cpp
+++ b/pegasus/src/Pegasus/DynListener/tests/TestDynListener/TestListener.cpp
@@ -258,7 +258,7 @@ int main()
         printf("CIMException %s\n",
                (const char*)ce.getMessage().getCString());
     }
-    catch (Exception e)
+    catch (const Exception& e)
     {
         printf("Exception %s\n",
                (const char*)e.getMessage().getCString());
@@ -266,4 +266,3 @@ int main()
 
     return 0;
 }
-

--- a/pegasus/src/Pegasus/FQL/FQLOperand.cpp
+++ b/pegasus/src/Pegasus/FQL/FQLOperand.cpp
@@ -287,7 +287,7 @@ Boolean FQLOperand::getIndexedValue(const FQLOperand& fromOp, Uint32 index)
                 break;
             }
         }
-        catch (IndexOutOfBoundsException)
+        catch (const IndexOutOfBoundsException&)
         {
             return false;
         }

--- a/pegasus/src/Pegasus/FQL/FQLOperand.h
+++ b/pegasus/src/Pegasus/FQL/FQLOperand.h
@@ -258,7 +258,7 @@ public:
         {
             _dateTimeValue.set(x);
         }
-        catch (InvalidDateTimeFormatException)
+        catch (const InvalidDateTimeFormatException&)
         {
             throw TypeMismatchException();
         }
@@ -284,7 +284,7 @@ public:
                 _arrayDateTimeValue.append(y);
             }
         }
-        catch (InvalidDateTimeFormatException)
+        catch (const InvalidDateTimeFormatException&)
         {
             throw TypeMismatchException();
         }
@@ -309,7 +309,7 @@ public:
         {
             _referenceValue = CIMObjectPath(x);
         }
-        catch (MalformedObjectNameException)
+        catch (const MalformedObjectNameException&)
         {
             throw TypeMismatchException();
         }
@@ -344,7 +344,7 @@ public:
                 _arrayReferenceValue.append(y);
             }
         }
-        catch (MalformedObjectNameException)
+        catch (const MalformedObjectNameException&)
         {
             throw TypeMismatchException();
         }
@@ -582,7 +582,7 @@ public:
             {
                return CIMDateTime(_stringValue);
             }
-            catch (InvalidDateTimeFormatException)
+            catch (const InvalidDateTimeFormatException&)
             {
                 throw TypeMismatchException();
             }
@@ -603,7 +603,7 @@ public:
             {
                return CIMObjectPath(String(_stringValue));
             }
-            catch (...)
+            catch (const Exception&)
             {
                 throw TypeMismatchException();
             }
@@ -633,7 +633,7 @@ public:
                     rtn.append(CIMDateTime(_arrayStringValue[i]));
                 }
             }
-            catch (InvalidDateTimeFormatException)
+            catch (const InvalidDateTimeFormatException&)
             {
                 throw TypeMismatchException();
             }
@@ -667,7 +667,7 @@ public:
                     rtn.append(CIMObjectPath(_arrayStringValue[i]));
                 }
             }
-            catch (MalformedObjectNameException)
+            catch (const MalformedObjectNameException&)
             {
                 throw TypeMismatchException();
             }
@@ -940,4 +940,3 @@ private:
 PEGASUS_NAMESPACE_END
 
 #endif /* Pegasus_FQLOperand_h */
-

--- a/pegasus/src/Pegasus/FQL/FQLQueryStatementRep.cpp
+++ b/pegasus/src/Pegasus/FQL/FQLQueryStatementRep.cpp
@@ -408,6 +408,7 @@ static Boolean _Evaluate(
                         op);
                 }
             }
+
             // In this case, the right hand might still be String and we
             // must convert
             case FQLOperand::REFERENCE_VALUE:
@@ -427,6 +428,7 @@ static Boolean _Evaluate(
                         op);
                 }
             }
+
             case FQLOperand::PROPERTY_NAME:
                 PEGASUS_ASSERT(0);
         }
@@ -434,7 +436,7 @@ static Boolean _Evaluate(
     }
 
     // Catch the specific IndexOutOf range set by FQLOperand.h
-    catch (IndexOutOfBoundsException)
+    catch (const IndexOutOfBoundsException&)
     {
 #ifdef FQL_DOTRACE
         DCOUT << "Caught index out of Bounds Exception" << endl;
@@ -739,6 +741,8 @@ Boolean FQLQueryStatementRep::evaluateQuery(
                 // All operations allowed
                 allComparesAllowed = true;
             }
+            // fall through
+            /* FALLTHRU */
             case FQL_LT:
             case FQL_LE:
             case FQL_GT:
@@ -832,7 +836,8 @@ Boolean FQLQueryStatementRep::evaluateQuery(
             case FQL_NOT_ANY:
             case FQL_NOT_EVERY:
                 isNotType = true;
-
+                // fall through
+                /* FALLTHRU */
             case FQL_EVERY:
             case FQL_ANY:
                 {

--- a/pegasus/src/Pegasus/HandlerService/tests/ReliableIndicationDisableEnable/ReliableIndicationDisableEnableTest.cpp
+++ b/pegasus/src/Pegasus/HandlerService/tests/ReliableIndicationDisableEnable/ReliableIndicationDisableEnableTest.cpp
@@ -156,7 +156,7 @@ void MyIndicationConsumer::consumeIndication(
           << receivedIndicationCount.get()
           << " of " << indicationSendCountTotal << endl;
     }
- 
+
     //
     // Get the date and time from the indication
     // Compare it to the current date
@@ -939,7 +939,7 @@ ThreadReturnType PEGASUS_THREAD_CDECL _executeTests(void *parm)
         elapsedTime.stop();
         _testEnd(uniqueID, elapsedTime.getElapsed());
     }
-    catch(Exception e)
+    catch(Exception& e)
     {
         cout << e.getMessage() << endl;
     }
@@ -1055,15 +1055,15 @@ int _beginTest(CIMClient& workClient, const char* opt,
         if (monitorClientResidentListener)
         {
             // Add our consumer
-            // CIMListener will be not started yet 
-            // It will be started after sending indication 
+            // CIMListener will be not started yet
+            // It will be started after sending indication
             // so that a temporary indication delivery failure
-            // will occur and after then CIMListener 
-            // will be started so that for reliable indication 
-            // enable, indication will be delivered after few retry 
-            // and for reliable indication disable,indication will  be 
-            // not delivered.    
-            
+            // will occur and after then CIMListener
+            // will be started so that for reliable indication
+            // enable, indication will be delivered after few retry
+            // and for reliable indication disable,indication will  be
+            // not delivered.
+
             listener.addConsumer(consumer1);
         }
 
@@ -1185,11 +1185,11 @@ int _beginTest(CIMClient& workClient, const char* opt,
                 throw;
             }
         }
- 
+
         while (noChangeIterations <= MAX_NO_CHANGE_ITERATIONS)
         {
             totalIterations++;
- 
+
            System::sleep (SLEEP_SEC);
 
             if (monitorClientResidentListener)
@@ -1291,12 +1291,12 @@ int _beginTest(CIMClient& workClient, const char* opt,
             }
             else
             {
-                 cout << " Indications Sent and  Received Not Matched " << endl 
+                 cout << " Indications Sent and  Received Not Matched " << endl
                       << endl;
 
             }
 
-            
+
         }
 
 

--- a/pegasus/src/Providers/ManagedSystem/Process/Process_Linux.cpp
+++ b/pegasus/src/Providers/ManagedSystem/Process/Process_Linux.cpp
@@ -1114,7 +1114,7 @@ Boolean get_proc(peg_proc_t* P, int &pIndex , Boolean find_by_pid)
 {
   static struct dirent *dir;
   static struct stat stat_buff;
-  static char path[32];
+  static char path[512];
   static char buffer[512];
   DIR* procDir;
   int count;
@@ -1233,6 +1233,3 @@ void doPercentCPU(char *inputFileString, peg_proc_t *P)
    }
    else P->pst_pctcpu = 0;
 }
-
-
-

--- a/pegasus/src/Providers/TestProviders/IndicationStressTestProvider/testclient/IndicationStressTest.cpp
+++ b/pegasus/src/Providers/TestProviders/IndicationStressTestProvider/testclient/IndicationStressTest.cpp
@@ -1036,7 +1036,7 @@ ThreadReturnType PEGASUS_THREAD_CDECL _executeTests(void *parm)
         elapsedTime.stop();
         _testEnd(uniqueID, elapsedTime.getElapsed());
     }
-    catch(Exception e)
+    catch(const Exception & e)
     {
         cout << e.getMessage() << endl;
     }


### PR DESCRIPTION
This pr also fixes a number of other minor warning message issues
as documented below.

This pr corrects the majority of both of these warning types.

It also corrects an issue in CIMCLICommand with a type mismatch in
comparison

Update OSINFO.cpp sprintf max size specification

Removed XMLProcess.* throw specification

This is deprecated in C++11 and is to be removed in C++17 and shows up
as warning with gcc. The only goal was to limit the exceptions that
could be thrown by the entity for which it was included, not to throw a
specific exception.

This is no real reason for it in our code.

Modify catch parameter to make it a reference

Add bread to case statements to remove compiler warning

Make catch parameter a reference in TestListener.cpp

Make catch parameter reference in ReliableIndicationDisableEnable test

Increate sprintf buffer size in Process_Linux.cpp to remove warning

Make catch parameter reference in Indication test client

Add break; statemetn to InteropProvider.cpp

Add break; statement to CQLFunctionRep.cpp

Modify catch parameter to define as reference in CQLValue.cpp

Outdent lines in CIMOperationRequestDecoder.cpp that had warning

Add FALLTHROUGH comment to case in PUllErrors.cpp

Separate string and var by space to avoid warning in InternalException.cpp