### PR TITLE
Fixes issue #7 - deprecated warning message on use of readdir_r

### DIFF
--- a/pegasus/mak/config-linux.mak
+++ b/pegasus/mak/config-linux.mak
@@ -113,6 +113,8 @@ else
   ifeq ($(shell expr $(GCC_VERSION) '>=' 8.0), 1)
     FLAGS += -Wno-class-memaccess
     FLAGS += -Wno-deprecated-copy
+    # See github issue #7. Specifically bypasses depracated readdir_r
+    FLAGS += -Wno-deprecated-declarations
   endif
     FLAGS += -D_GNU_SOURCE -DTHREAD_SAFE -D_REENTRANT
 endif


### PR DESCRIPTION
This function is considered obsolete and is deprecated in favor of using
readdir directly.  OpenPegasus uses readdir_r in two ways.

1. Several methods use it to access the disk directories, primarily some
providers.

2. There is a common class in OpenPegasus (src/Pegasus/Common/DirPOSIX
that is available to any Pegasus functionality that uses readdir_r

Since our usage is somewhat complex in that there are threading issues
in moving from readdir_r to readdir, we are simply hiding the warning
for the moment.