### PR TITLE
Fix case-statement compile warnings and some other issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,37 @@
 
 This repository is the OpenPegasus source code starting with OpenPegasus 14.1.
 
-NOTE: This repository is a development repository to enable port of
+
+NOTE: This repository is a development repository to enable p
 OpenPegasus from cvs to github in a manner that can be supported with
 future versions of OpenPegasus and to support creating new versions of
-OpenPegasus.
+OpenPegasus.  Before release, OpenPegasus may be moved to a separate github
+project/repository.
 
 The intial release of OpenPegasus in github is expected to be OpenPegasus
 version 14.2
+
+Version 14.2 Development status and goals
+
+GOALS (This may change)
+
+1. Update pegasus to remove compile warnings/errors resulting from use of
+   new compilers (i.e. gcc move from 4.5 to 9.0)
+
+2. Test with at least 1. Linux 0 gcc compiler, 2. Windows microsoft compiler
+   since these are the default compilers for OpenPegasus
+
+3. Provide an up-to-date OpenPegasus on github publicly available
+
+4. Provide CI testing of OpenPegasus on github
+
+6. Extend the github OpenPegasus to make user of github facilities such as
+   better documentation tools, etc.
+
+7. Extend OpenPegasus to support the OpenSSL 1.1 API which differs significantly
+   from the 1.0.2 API that OpenPegasus currently supports.
+
+Status Today:
+
+1. Compile reduced from several hundered warnings to a very few on gcc
+   9.x linux

--- a/pegasus/src/Pegasus/Common/CommonUTF.cpp
+++ b/pegasus/src/Pegasus/Common/CommonUTF.cpp
@@ -83,16 +83,19 @@ Boolean isValid_U8(const Uint8 *src, int size)
     const Uint8 *srcptr = src+size;
     switch (size)
     {
+    // TODO/KS: review. Executes same code for case 4 and 3
     case 4:
         if ((U8_char = (*--srcptr)) < 0x80 || U8_char > 0xBF)
         {
         return false;
         }
+        /* FALLTHROUGH */
     case 3:
         if ((U8_char = (*--srcptr)) < 0x80 || U8_char > 0xBF)
         {
         return false;
         }
+        /* FALLTHROUGH */
     case 2:
         if ((U8_char = (*--srcptr)) > 0xBF)
         {
@@ -124,6 +127,7 @@ Boolean isValid_U8(const Uint8 *src, int size)
             return false;
             }
         }
+        /* FALLTHROUGH */
     case 1:
         if (*src >= 0x80 && *src < 0xC2)
         {
@@ -226,12 +230,15 @@ int UTF16toUTF8(const Uint16** srcHead,
         case 4:
         *--tgt = (Uint8)((tempchar | 0x80) & 0xBF);
         tempchar >>= 6;
+        /* FALLTHROUGH */
         case 3:
         *--tgt = (Uint8)((tempchar | 0x80) & 0xBF);
         tempchar >>= 6;
+        /* FALLTHROUGH */
         case 2:
         *--tgt = (Uint8)((tempchar | 0x80) & 0xBF);
         tempchar >>= 6;
+        /* FALLTHROUGH */
         case 1:
         *--tgt =  (Uint8)(tempchar | firstByteMark[numberOfBytes]);
     }
@@ -264,12 +271,15 @@ int UTF8toUTF16 (const Uint8** srcHead,
         case 3:
         tempchar += *src++;
         tempchar <<= 6;
+        /* FALLTHROUGH */
         case 2:
         tempchar += *src++;
         tempchar <<= 6;
+        /* FALLTHROUGH */
         case 1:
         tempchar += *src++;
         tempchar <<= 6;
+        /* FALLTHROUGH */
         case 0:
         tempchar += *src++;
     }

--- a/pegasus/src/Pegasus/Common/XmlReader.cpp
+++ b/pegasus/src/Pegasus/Common/XmlReader.cpp
@@ -949,7 +949,7 @@ CIMValue XmlReader::stringToValue(
                 default: break;
             }
         }
-
+        /* FALLTHROUGH */
         case CIMTYPE_SINT8:
         case CIMTYPE_SINT16:
         case CIMTYPE_SINT32:
@@ -964,7 +964,7 @@ CIMValue XmlReader::stringToValue(
                     "Invalid signed integer value");
                 throw XmlSemanticError(lineNumber, mlParms);
             }
-
+            /* FALLTHROUGH */
             switch (type)
             {
                 case CIMTYPE_SINT8:
@@ -1004,7 +1004,7 @@ CIMValue XmlReader::stringToValue(
                 default: break;
             }
         }
-
+        /* FALLTHROUGH */
         case CIMTYPE_DATETIME:
         {
             CIMDateTime tmp;

--- a/pegasus/src/Pegasus/Common/tests/SCMOStreamer/TestSCMOStreamer.cpp
+++ b/pegasus/src/Pegasus/Common/tests/SCMOStreamer/TestSCMOStreamer.cpp
@@ -51,7 +51,7 @@ const String TESTSCMO2XML("/src/Pegasus/Common/tests/SCMOStreamer/");
 #define TEST_INSTANCE_ID "my_instance_id"
 #define TEST_ERROR_SOURCE "my_error_source"
 #define TEST_PRE_METHOD_NAME "my_pre_method_name"
-#define TEST_POST_METHOD_NAME "my_post_method_name"
+#define TEST_POST_METHOD_NAME (char*)"my_post_method_name"
 
 SCMOClass _scmoClassCache_GetClass(
     const CIMNamespaceName& nameSpace,
@@ -121,7 +121,7 @@ void SCMOInstanceConverterTest()
 
     VCOUT << endl << "Creating PostCall instance" << endl;
     SCMOInstance postCall = SCMOInstance(CIM_InstMethodCall);
-    val.extString.pchar  = TEST_POST_METHOD_NAME;
+    val.extString.pchar  = (char*)TEST_POST_METHOD_NAME;
     val.extString.length = strlen(val.extString.pchar);
     postCall.setPropertyWithOrigin("MethodName", CIMTYPE_STRING, &val);
     val.extRefPtr = &error;

--- a/pegasus/src/Pegasus/FQL/FQLOperand.h
+++ b/pegasus/src/Pegasus/FQL/FQLOperand.h
@@ -925,10 +925,10 @@ private:
 
     /// Type value for this operand
     Type _type;
+    bool _resolved;
+    bool _isArray;
     // Set when property types are resolved
     CIMType _cimType;
-    bool _isArray;
-    bool _resolved;
     propertyType propertyType;
     // Define existence of Property Operand with index
     // and the value of the index if _isIndexedProperty = true


### PR DESCRIPTION
1. Fixed any remaining implicitfallthrough warning messages.  In general
they were fixed by simply adding the /* FALLTHROUGH */ comment that
servers as a compile version independent flag for this warning message.
  We tried not to change the code itself.

2. Fix issue with typing incompatibility warning

3. Added information to the README.md on the current status of this work
pending a more complete approach with the information in an issue.