### PR TITLE
Fixes issue #9, update pegasus version number and status

### DIFF
--- a/pegasus/src/Pegasus/Common/PegasusVersion.h
+++ b/pegasus/src/Pegasus/Common/PegasusVersion.h
@@ -72,8 +72,8 @@
 
 # define PEGASUS_PRODUCT_NAME    "CIM Server"
 
-# define PEGASUS_PRODUCT_STATUS  ""
-# define PEGASUS_PRODUCT_VERSION "2.14.1"
+# define PEGASUS_PRODUCT_STATUS  "Development"
+# define PEGASUS_PRODUCT_VERSION "2.14.2"
 
 # define PEGASUS_CIMOM_GENERIC_NAME "Pegasus"
 // If the following is non-zero length it becomes SLP description.
@@ -148,6 +148,6 @@ static const char *PLATFORM_EMBEDDED_IDENTIFICATION_STRING =
 // CAUTION: always check whether PEGASUS_VERSION_NUMBER is defined when
 // integrating with versions prior to 2.5.1.
 //
-#define PEGASUS_VERSION_NUMBER 0x02140100
+#define PEGASUS_VERSION_NUMBER 0x02140200
 
 #endif /* Pegasus_Version_h */


### PR DESCRIPTION
This PR only changes the internal representation of the version
number to 2.14.3 and the status to development.