### PR TITLE
Ks/#17 test openssl102

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ pegasus/src/Pegasus/Common/tests/Logger/log.trace.0
 pegasus/src/Pegasus/Common/tests/Tracer/testtracer4.trace.0
 pegasus/src/Pegasus/Server/tests/result
 *.log
+*.trace
 result
 
 # OpenPegasus files from running configure
@@ -11,6 +12,10 @@ pegasus/GNUmakefile
 pegasus/options.mak
 pegasus/options.mak.bak
 PegasusHome
+pegasus/cimserver_planned.conf
+bin/
+lib/
+lib32/
 
 
 # Prerequisites

--- a/pegasus/mak/config-linux.mak
+++ b/pegasus/mak/config-linux.mak
@@ -113,7 +113,7 @@ else
   ifeq ($(shell expr $(GCC_VERSION) '>=' 8.0), 1)
     FLAGS += -Wno-class-memaccess
     FLAGS += -Wno-deprecated-copy
-    # See github issue #7. Specifically bypasses depracated readdir_r
+    # See github issue #7. Specifically bypasses depricated readdir_r
     FLAGS += -Wno-deprecated-declarations
   endif
     FLAGS += -D_GNU_SOURCE -DTHREAD_SAFE -D_REENTRANT

--- a/pegasus/mak/config.mak
+++ b/pegasus/mak/config.mak
@@ -741,8 +741,6 @@ endif
 
 ifdef PEGASUS_HAS_SSL
     DEFINES += -DPEGASUS_HAS_SSL
-    # TODO set based on version TODO TODO
-    DEFINES += -DOPENSSL_API_COMPAT=0x10000000
 
     # Enable SSL Random file by default.
     ifndef PEGASUS_USE_SSL_RANDOMFILE

--- a/pegasus/src/Pegasus/Common/SSLContext.cpp
+++ b/pegasus/src/Pegasus/Common/SSLContext.cpp
@@ -56,6 +56,13 @@
 # include <ILEWrapper/ILEUtilities.h>
 #endif
 
+// If OpenSSL version  1.1.0 or greater set flag
+// Required because of API issues in version
+// 1.1.0
+# if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#  define OPENSSL_11
+# endif
+
 typedef struct x509_store_ctx_st X509_STORE_CTX;
 
 PEGASUS_USING_STD;
@@ -261,7 +268,7 @@ int SSLCallback::verificationCRLCallback(
 
     //initialize the CRL store
     // TODO: is this a 1.1.0 change to use pointers
-#if OPENSSL_API_COMPAT >= 0x10100000L
+#ifdef OPENSSL_11
     X509_STORE_CTX* crlStoreCtx = X509_STORE_CTX_new();
 
     X509_STORE_CTX_init(crlStoreCtx, sslCRLStore, NULL, NULL);
@@ -354,7 +361,7 @@ int SSLCallback::verificationCRLCallback(
         revokedCert = sk_X509_REVOKED_value(X509_CRL_get_REVOKED(crl), i);
         // A matching serial number indicates revocation
 
-#if OPENSSL_API_COMPAT >= 0x10100000L
+#ifdef OPENSSL_11
         // Cannot access serial number in 1.1.0 directly.
         // TODO: Why not use X509_CRL_get0_by_serial() or
         //                 or X509_CRL_get0_by_cert(crl, **ret, *x509)

--- a/pegasus/src/Pegasus/Common/SSLContextRep.h
+++ b/pegasus/src/Pegasus/Common/SSLContextRep.h
@@ -104,7 +104,11 @@ public:
 
             //important as per following site for 
             //http://www.openssl.org/support/faq.html#PROG
+#if OPENSSL_API_COMPAT < 0x10100000L
+            CRYPTO_malloc_init();
+#else
             OPENSSL_malloc_init();
+#endif
             SSL_library_init();
             SSL_load_error_strings();
         }
@@ -179,9 +183,10 @@ private:
     static void _uninitializeCallbacks()
     {
         PEG_TRACE_CSTRING(TRC_SSL, Tracer::LEVEL4, "Resetting SSL callbacks.");
-        // TODO: Removed in 1.1.0
-        // CRYPTO_set_locking_callback(NULL);
-        // CRYPTO_set_id_callback(NULL);
+#if OPENSSL_API_COMPAT < 0x10100000L
+        CRYPTO_set_locking_callback(NULL);
+        CRYPTO_set_id_callback(NULL);
+#endif
         _sslLocks.reset();
     }
 

--- a/pegasus/src/Pegasus/Common/SSLContextRep.h
+++ b/pegasus/src/Pegasus/Common/SSLContextRep.h
@@ -38,6 +38,11 @@
 # include <openssl/ssl.h>
 # include <openssl/rand.h>
 
+// Set flag if Openssl version ge 1.1.0
+# if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#  define OPENSSL_11
+# endif
+
 //Include the applink.c to stop crashes as per OpenSSL FAQ
 //http://www.openssl.org/support/faq.html#PROG
 # ifdef PEGASUS_OS_TYPE_WINDOWS
@@ -104,10 +109,10 @@ public:
 
             //important as per following site for 
             //http://www.openssl.org/support/faq.html#PROG
-#if OPENSSL_API_COMPAT < 0x10100000L
-            CRYPTO_malloc_init();
-#else
+#ifdef OPENSSL_11
             OPENSSL_malloc_init();
+#else            
+            CRYPTO_malloc_init();            
 #endif
             SSL_library_init();
             SSL_load_error_strings();
@@ -183,7 +188,7 @@ private:
     static void _uninitializeCallbacks()
     {
         PEG_TRACE_CSTRING(TRC_SSL, Tracer::LEVEL4, "Resetting SSL callbacks.");
-#if OPENSSL_API_COMPAT < 0x10100000L
+#ifndef OPENSSL_11
         CRYPTO_set_locking_callback(NULL);
         CRYPTO_set_id_callback(NULL);
 #endif

--- a/pegasus/src/Pegasus/ControlProviders/CertificateProvider/CertificateProvider.cpp
+++ b/pegasus/src/Pegasus/ControlProviders/CertificateProvider/CertificateProvider.cpp
@@ -65,6 +65,11 @@
 PEGASUS_USING_STD;
 PEGASUS_NAMESPACE_BEGIN
 
+// Set flag if OpenSSL version ge 1.1.0
+# if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#  define OPENSSL_11
+# endif
+
 // PG_SSLCertificate property names
 static const CIMName ISSUER_NAME_PROPERTY      =
     CIMNameCast("IssuerName");
@@ -534,7 +539,7 @@ inline CIMInstance _getCRLInstance(X509_CRL* xCrl, String host,
         // TODO: 1. Same as code in SSLContext. Make common method
         // 1.1.0 move to use
         // rawSerialNumber = ASN1_INTEGER_get(r->serialNumber);
-#if OPENSSL_API_COMPAT < 0x10100000L
+#ifndef OPENSSL_11
         rawSerialNumber = ASN1_INTEGER_get(r->serialNumber);
 #else
         rawSerialNumber = ASN1_INTEGER_get(X509_REVOKED_get0_serialNumber(r));
@@ -543,7 +548,7 @@ inline CIMInstance _getCRLInstance(X509_CRL* xCrl, String host,
         sprintf(serial, "%lu", (unsigned long)rawSerialNumber);
         revokedSerialNumbers.append(String(serial));
         // TODO: change pointer reference for OpenSSL 1.1.x
-#if OPENSSL_API_COMPAT < 0x10100000L
+#ifndef OPENSSL_11
         revocationDate = getDateTime(r->revocationDate);
 #else
         revocationDate = getDateTime(X509_REVOKED_get0_revocationDate(r));

--- a/pegasus/src/Pegasus/ControlProviders/CertificateProvider/CertificateProvider.cpp
+++ b/pegasus/src/Pegasus/ControlProviders/CertificateProvider/CertificateProvider.cpp
@@ -534,13 +534,20 @@ inline CIMInstance _getCRLInstance(X509_CRL* xCrl, String host,
         // TODO: 1. Same as code in SSLContext. Make common method
         // 1.1.0 move to use
         // rawSerialNumber = ASN1_INTEGER_get(r->serialNumber);
+#if OPENSSL_API_COMPAT < 0x10100000L
+        rawSerialNumber = ASN1_INTEGER_get(r->serialNumber);
+#else
         rawSerialNumber = ASN1_INTEGER_get(X509_REVOKED_get0_serialNumber(r));
+#endif
 
         sprintf(serial, "%lu", (unsigned long)rawSerialNumber);
         revokedSerialNumbers.append(String(serial));
         // TODO: change pointer reference for OpenSSL 1.1.x
-        //revocationDate = getDateTime(r->revocationDate);
+#if OPENSSL_API_COMPAT < 0x10100000L
+        revocationDate = getDateTime(r->revocationDate);
+#else
         revocationDate = getDateTime(X509_REVOKED_get0_revocationDate(r));
+#endif
 
         revocationDates.append(revocationDate);
     }

--- a/pegasus/src/Pegasus/ControlProviders/InteropProvider/ElementConformsToProfile.cpp
+++ b/pegasus/src/Pegasus/ControlProviders/InteropProvider/ElementConformsToProfile.cpp
@@ -154,7 +154,7 @@ Array<CIMInstance> InteropProvider::enumElementConformsToProfileInstances(
                 opNamespace == currentNamespace)
             {
                 String currentElementStr(currentElement.getString());
-                if (currentElementStr.find(PEGASUS_DYNAMIC) == 0)
+                if (currentElementStr.find(PEGASUS_DYNAMIC.size()) == 0)
                 {
                     // If the provider profile registration did not provide a
                     // list of conforming elements (presumably because there is
@@ -166,7 +166,7 @@ Array<CIMInstance> InteropProvider::enumElementConformsToProfileInstances(
                         continue;
                     }
                     CIMName subclassName(
-                        currentElementStr.subString(PEGASUS_DYNAMIC_LEN));
+                        currentElementStr.subString(PEGASUS_DYNAMIC.size()));
                     Array<CIMInstance> elementConformsInstances =
                         cimomHandle.enumerateInstances(opContext,
                         currentNamespace, subclassName, true, false, false,

--- a/pegasus/src/Pegasus/ControlProviders/InteropProvider/ElementConformsToProfile.cpp
+++ b/pegasus/src/Pegasus/ControlProviders/InteropProvider/ElementConformsToProfile.cpp
@@ -154,7 +154,7 @@ Array<CIMInstance> InteropProvider::enumElementConformsToProfileInstances(
                 opNamespace == currentNamespace)
             {
                 String currentElementStr(currentElement.getString());
-                if (currentElementStr.find(PEGASUS_DYNAMIC.size()) == 0)
+                if (currentElementStr.find(PEGASUS_DYNAMIC) == 0)
                 {
                     // If the provider profile registration did not provide a
                     // list of conforming elements (presumably because there is
@@ -166,7 +166,7 @@ Array<CIMInstance> InteropProvider::enumElementConformsToProfileInstances(
                         continue;
                     }
                     CIMName subclassName(
-                        currentElementStr.subString(PEGASUS_DYNAMIC.size()));
+                        currentElementStr.subString(PEGASUS_DYNAMIC_LEN));
                     Array<CIMInstance> elementConformsInstances =
                         cimomHandle.enumerateInstances(opContext,
                         currentNamespace, subclassName, true, false, false,

--- a/pegasus/src/Pegasus/ControlProviders/InteropProvider/InteropConstants.h
+++ b/pegasus/src/Pegasus/ControlProviders/InteropProvider/InteropConstants.h
@@ -150,7 +150,8 @@ const String PEGASUS_INTERNAL_PROVIDER_TYPE(
 const String PEGASUS_INTERNAL_SERVICE_TYPE(
     "Internal Service");
 const String PEGASUS_DYNAMIC("__DYNAMIC_");
-const Uint32 PEGASUS_DYNAMIC_LEN(PEGASUS_DYNAMIC.size());
+// const Uint32 PEGASUS_DYNAMIC_LEN(PEGASUS_DYNAMIC.size());
+
 const CIMNamespaceName PEGASUS_NAMESPACENAME_ROOT("root");
 
 #define thisProvider "InteropProvider"

--- a/pegasus/src/Pegasus/ControlProviders/InteropProvider/InteropConstants.h
+++ b/pegasus/src/Pegasus/ControlProviders/InteropProvider/InteropConstants.h
@@ -149,8 +149,9 @@ const String PEGASUS_INTERNAL_PROVIDER_TYPE(
     "Internal Control Provider");
 const String PEGASUS_INTERNAL_SERVICE_TYPE(
     "Internal Service");
+
 const String PEGASUS_DYNAMIC("__DYNAMIC_");
-// const Uint32 PEGASUS_DYNAMIC_LEN(PEGASUS_DYNAMIC.size());
+const Uint32 PEGASUS_DYNAMIC_LEN(PEGASUS_DYNAMIC.size());
 
 const CIMNamespaceName PEGASUS_NAMESPACENAME_ROOT("root");
 

--- a/pegasus/src/Pegasus/ProviderManager2/JMPI/org/pegasus/jmpi/tests/Client/testIndications.java
+++ b/pegasus/src/Pegasus/ProviderManager2/JMPI/org/pegasus/jmpi/tests/Client/testIndications.java
@@ -49,7 +49,7 @@ public class testIndications
 {
    private final static String className           = "JMPIExpIndication";
    private final static String nameSpaceClass      = "root/SampleProvider";
-   private final static String nameSpaceInterOp    = "root/PG_InterOp";
+   private final static String nameSpaceInterOp    = "root/interop";
    private final static String nameSpaceCIMV2      = "root/cimv2";
 
    private static boolean      DEBUG               = false;
@@ -237,7 +237,7 @@ public class testIndications
 
       try
       {
-         cop = new CIMObjectPath ("PG_NameSpace", "root/PG_InterOp");
+         cop = new CIMObjectPath ("PG_NameSpace", "root/interop");
          enm = cc.enumInstances (cop,
                                  true,   // deepInheritance
                                  true);  // localOnly

--- a/pegasus/src/Pegasus/ProviderManager2/JMPI/org/pegasus/jmpi/tests/Providers/Properties/JMPIPropertyProvider.java
+++ b/pegasus/src/Pegasus/ProviderManager2/JMPI/org/pegasus/jmpi/tests/Providers/Properties/JMPIPropertyProvider.java
@@ -757,7 +757,7 @@ public class JMPIPropertyProvider
    }
 
    private static final String NAMESPACE               = "root/SampleProvider";
-   private static final String NAMESPACE_INTEROP       = "root/PG_InterOp";
+   private static final String NAMESPACE_INTEROP       = "root/interop";
 
    // Class names
    private static final String CLASS_PROPERTYTYPES     = "JMPIProperty_TestPropertyTypes";

--- a/pegasus/src/Pegasus/ProviderManager2/JMPI/org/pegasus/jmpi/tests/Static/ErrorXml/DuplicateProperty01.xml
+++ b/pegasus/src/Pegasus/ProviderManager2/JMPI/org/pegasus/jmpi/tests/Static/ErrorXml/DuplicateProperty01.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="CreateInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="NewInstance">
           <INSTANCE CLASSNAME="PG_IndicationSubscription">

--- a/pegasus/src/Pegasus/ProviderManager2/JMPI/org/pegasus/jmpi/tests/Static/ErrorXml/MissingInstanceNameClassName01.xml
+++ b/pegasus/src/Pegasus/ProviderManager2/JMPI/org/pegasus/jmpi/tests/Static/ErrorXml/MissingInstanceNameClassName01.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="CreateInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="NewInstance">
           <INSTANCE CLASSNAME="PG_IndicationSubscription">

--- a/pegasus/src/Pegasus/ProviderManager2/JMPI/org/pegasus/jmpi/tests/Static/ErrorXml/MissingKeyValue01.xml
+++ b/pegasus/src/Pegasus/ProviderManager2/JMPI/org/pegasus/jmpi/tests/Static/ErrorXml/MissingKeyValue01.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="ModifyInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="ModifiedInstance">
           <VALUE.NAMEDINSTANCE>

--- a/pegasus/src/Pegasus/ProviderManager2/JMPI/org/pegasus/jmpi/tests/Static/ErrorXml/MissingKeyValueEndTag01.xml
+++ b/pegasus/src/Pegasus/ProviderManager2/JMPI/org/pegasus/jmpi/tests/Static/ErrorXml/MissingKeyValueEndTag01.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="ModifyInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="ModifiedInstance">
           <VALUE.NAMEDINSTANCE>

--- a/pegasus/src/Pegasus/ProviderManager2/JMPI/org/pegasus/jmpi/tests/Static/ErrorXml/MissingPropertyReferenceEndTag01.xml
+++ b/pegasus/src/Pegasus/ProviderManager2/JMPI/org/pegasus/jmpi/tests/Static/ErrorXml/MissingPropertyReferenceEndTag01.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="CreateInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="NewInstance">
           <INSTANCE CLASSNAME="PG_IndicationSubscription">

--- a/pegasus/src/Pegasus/ProviderManager2/JMPI/org/pegasus/jmpi/tests/Static/ErrorXml/MissingValueArray01.xml
+++ b/pegasus/src/Pegasus/ProviderManager2/JMPI/org/pegasus/jmpi/tests/Static/ErrorXml/MissingValueArray01.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="ModifyInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="ModifiedInstance">
           <VALUE.NAMEDINSTANCE>

--- a/pegasus/src/Pegasus/Server/tests/TLSv_1_2_Support/TestTLSv1_2_Support.cpp
+++ b/pegasus/src/Pegasus/Server/tests/TLSv_1_2_Support/TestTLSv1_2_Support.cpp
@@ -37,6 +37,7 @@
 
 
 #ifdef PEGASUS_HAS_SSL
+#  include <openssl/ssl.h>
 #  include <openssl/tls1.h>
 #endif
 

--- a/pegasus/src/Pegasus/msg/Server/pegasusServer_en.txt
+++ b/pegasus/src/Pegasus/msg/Server/pegasusServer_en.txt
@@ -3141,9 +3141,9 @@ en:table {
 
         /**
         * @note  PGS06404:
-        *    Do not translate the word 'root/PG_InterOp' since it is a path/CIM class name
+        *    Do not translate the word 'root/interop' since it is a path/CIM class name
         */
-        Server.ProviderRegistrationManager.ProviderRegistrationManager.REPOSITORY_CORRUPTED:string {"PGS06404: The provider registration schema in namespace \"root/PG_InterOp\" is corrupted."}
+        Server.ProviderRegistrationManager.ProviderRegistrationManager.REPOSITORY_CORRUPTED:string {"PGS06404: The provider registration schema in namespace \"root/interop\" is corrupted."}
 
         /**
         * @note  PGS06405:

--- a/pegasus/src/Providers/TestProviders/CLITestProvider/tests/namespacetestresult.master
+++ b/pegasus/src/Providers/TestProviders/CLITestProvider/tests/namespacetestresult.master
@@ -1,5 +1,5 @@
 19. +++++ namespacetests
-root/PG_InterOp
+root/interop
 root/benchmark
 root/SampleProvider
 test/CimsubTestNS2

--- a/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaCapability.xml
+++ b/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaCapability.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="CreateInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="NewInstance">
           <INSTANCE CLASSNAME="PG_ProviderCapabilities">
@@ -23,7 +23,7 @@
             </PROPERTY>
             <PROPERTY.ARRAY NAME="Namespaces" TYPE="string">
               <VALUE.ARRAY>
-                <VALUE> root/PG_InterOp </VALUE>
+                <VALUE> root/interop </VALUE>
                 <VALUE> root/cimv2 </VALUE>
               </VALUE.ARRAY>
             </PROPERTY.ARRAY>

--- a/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaFilter.xml
+++ b/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaFilter.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="CreateInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="NewInstance">
           <INSTANCE CLASSNAME="CIM_IndicationFilter">

--- a/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaHandlerV1.xml
+++ b/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaHandlerV1.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="CreateInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="NewInstance">
           <INSTANCE CLASSNAME="PG_IndicationHandlerSNMPMapper">

--- a/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaHandlerV2.xml
+++ b/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaHandlerV2.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="CreateInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="NewInstance">
           <INSTANCE CLASSNAME="PG_IndicationHandlerSNMPMapper">

--- a/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaHandlerXmlLocal.xml
+++ b/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaHandlerXmlLocal.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="CreateInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="NewInstance">
           <INSTANCE CLASSNAME="CIM_IndicationHandlerCIMXML">

--- a/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaHandlerXmlRemote.xml
+++ b/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaHandlerXmlRemote.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="CreateInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="NewInstance">
           <INSTANCE CLASSNAME="CIM_IndicationHandlerCIMXML">

--- a/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaModule.xml
+++ b/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaModule.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="CreateInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="NewInstance">
           <INSTANCE CLASSNAME="PG_ProviderModule">

--- a/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaProvider.xml
+++ b/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaProvider.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="CreateInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="NewInstance">
           <INSTANCE CLASSNAME="PG_Provider">

--- a/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaSubXmlLocal.xml
+++ b/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaSubXmlLocal.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="CreateInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="NewInstance">
           <INSTANCE CLASSNAME="CIM_IndicationSubscription">

--- a/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaSubXmlRemote.xml
+++ b/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaSubXmlRemote.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="CreateInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="NewInstance">
           <INSTANCE CLASSNAME="CIM_IndicationSubscription">

--- a/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaSubv1.xml
+++ b/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaSubv1.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="CreateInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="NewInstance">
           <INSTANCE CLASSNAME="CIM_IndicationSubscription">

--- a/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaSubv2.xml
+++ b/pegasus/src/Providers/sample/SNMPIndicationProvider/nsaSubv2.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="CreateInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="NewInstance">
           <INSTANCE CLASSNAME="CIM_IndicationSubscription">

--- a/pegasus/src/SDK/samples/Clients/DefaultC++/SendTestIndications/SendTestIndications.cpp
+++ b/pegasus/src/SDK/samples/Clients/DefaultC++/SendTestIndications/SendTestIndications.cpp
@@ -43,7 +43,7 @@
 PEGASUS_USING_PEGASUS;
 PEGASUS_USING_STD;
 
-const CIMNamespaceName INTEROPNAMESPACE = CIMNamespaceName("root/PG_InterOp");
+const CIMNamespaceName INTEROPNAMESPACE = CIMNamespaceName("root/interop");
 const CIMNamespaceName
     SOURCENAMESPACE = CIMNamespaceName ("SDKExamples/DefaultCXX");
 static const CIMName

--- a/pegasus/test/wetest/static/ErrorXml/DuplicateProperty01.xml
+++ b/pegasus/test/wetest/static/ErrorXml/DuplicateProperty01.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="CreateInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="NewInstance">
           <INSTANCE CLASSNAME="PG_IndicationSubscription">

--- a/pegasus/test/wetest/static/ErrorXml/MissingInstanceNameClassName01.xml
+++ b/pegasus/test/wetest/static/ErrorXml/MissingInstanceNameClassName01.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="CreateInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="NewInstance">
           <INSTANCE CLASSNAME="PG_IndicationSubscription">

--- a/pegasus/test/wetest/static/ErrorXml/MissingKeyValue01.xml
+++ b/pegasus/test/wetest/static/ErrorXml/MissingKeyValue01.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="ModifyInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="ModifiedInstance">
           <VALUE.NAMEDINSTANCE>

--- a/pegasus/test/wetest/static/ErrorXml/MissingKeyValueEndTag01.xml
+++ b/pegasus/test/wetest/static/ErrorXml/MissingKeyValueEndTag01.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="ModifyInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="ModifiedInstance">
           <VALUE.NAMEDINSTANCE>

--- a/pegasus/test/wetest/static/ErrorXml/MissingPropertyReferenceEndTag01.xml
+++ b/pegasus/test/wetest/static/ErrorXml/MissingPropertyReferenceEndTag01.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="CreateInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="NewInstance">
           <INSTANCE CLASSNAME="PG_IndicationSubscription">

--- a/pegasus/test/wetest/static/ErrorXml/MissingValueArray01.xml
+++ b/pegasus/test/wetest/static/ErrorXml/MissingValueArray01.xml
@@ -5,7 +5,7 @@
       <IMETHODCALL NAME="ModifyInstance">
         <LOCALNAMESPACEPATH>
           <NAMESPACE NAME="root"/>
-          <NAMESPACE NAME="PG_InterOp"/>
+          <NAMESPACE NAME="interop"/>
         </LOCALNAMESPACEPATH>
         <IPARAMVALUE NAME="ModifiedInstance">
           <VALUE.NAMEDINSTANCE>


### PR DESCRIPTION
Complete clean up of ssl interface for openssl 102.  opnessl compatibility added in previous commit but that broke some backward compatibility

Restore the default interop namespace to root/PG_Interop

This not the final issue # 17 pr in that we still have some tests of cert revocation to test

