### PR TITLE
Marked Pegasus version as Pre-Release. 

### DIFF
--- a/pegasus/src/Pegasus/Common/PegasusVersion.h
+++ b/pegasus/src/Pegasus/Common/PegasusVersion.h
@@ -72,7 +72,7 @@
 
 # define PEGASUS_PRODUCT_NAME    "CIM Server"
 
-# define PEGASUS_PRODUCT_STATUS  "Development"
+# define PEGASUS_PRODUCT_STATUS  "Pre-Release"
 # define PEGASUS_PRODUCT_VERSION "2.14.2"
 
 # define PEGASUS_CIMOM_GENERIC_NAME "Pegasus"


### PR DESCRIPTION
This PR sets the pre_release flag inside OpenPegasus
Only serious issues will be considered subsequent to ths change.