### PR TITLE
Fixes issue #84 Implement extension to test provider to test delayed responses

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -8,14 +8,33 @@ Change log
 .. ifconfig:: '.dev' in version
 
    This version of the documentation is development version |version| and
-   contains the `master` branch up to this commit:
+   contains the `main` branch up to this commit:
 
    .. git_changelog::
       :revisions: 1
 
+openpegasus 14.3-dev
+--------------------
 
-openpegasus 14.2.dev1
----------------------
+Status: Development
+
+Bugs
+
+
+Enhancements
+
+* Add test capability to test delays from the server with a provider.  This
+  enhances the CLITestProvider to add a method delayedMethodResponse that
+  includes a parameter delayInSeconds.  When this method is called, it delays
+  the response by the value of delayInSeconds (see issue #84)
+
+cleanup
+
+
+openpegasus 14.2 - Release
+--------------------------
+
+Status: Released 21 June 2021
 
 Bugs
 
@@ -28,7 +47,7 @@ Bugs
 
 2. Fix issue with literal use of root/PG_Interop in Makefile for
    Client/test/pullop/pullop.cpp. (See issue #2)
-   
+
 3. Issue with pulltest and namespaces fixed (Issue #3)
 
 3. Fix code from warning messages for vsprintf, etc. where the buffer could
@@ -43,25 +62,25 @@ Bugs
 
 6. Fix issue with function valid() in Pegasus/Common/Message.cpp that was causing
    issue in non-debug mode.  (see issue #12 and #19)
-   
+
 7. MOF compiler fails with mof where EmbeddedInstance is in a non-leaf class (see
    issue #50)
-   
+
 8. The certificate and key files in pegasus/src/Server were built a number of years
    ago and were obsolete, expired and with SHA1 rather than SHA256 for digest
    definition. They would not pass tests.  These certificates and keys were rebuilt
    to update the dates and the characteristics to be usable with OpenSSL 1.1.1. See
    issue #63)
-   
+
 9. Upgrade OpenPegasus SSL functions to interface with OpenSSL 1.1.x.  This version
    of OpenSSL is a significatn API change from the 1.0.2 version. (see issue #17)
-   
+
 10. Fix issue in Message.cpp causing failure in not-debug mode. (see issue #19)
 
-11. Fixed a number of minor spelling bugs in the help, specifically  the 
+11. Fixed a number of minor spelling bugs in the help, specifically  the
    configuration help.
 
-   
+
 Enhancements
 
 1. Integrate DMTF schema 2.41 experimental into OpenPegasus schemas.  This required
@@ -69,12 +88,12 @@ Enhancements
    modifying the list of mof files in the Schemas directory for CIMExperimental241
    (See issue #46, #62). Note that the test suite cannot be run with this schema because
    the test suite depends on particular class definitions. Isee issue #52 and #62
-   
+
 2. Allow defintion of Experimental DMTF schema as OpenPegasus repositories (see issue #51)
 
 3. Expand SSL support to include OpenSSL versions 1.1.0+ including updated
    OpenSSL APIs. (See issue #17)
-   
+
 
 cleanup
 
@@ -101,4 +120,3 @@ branch: release_14_1
 
 This version of OpenPegasus is maintained in the OpenGroup CVS repository and the
 changes are documented in the OpenPegasus WEB site.
-

--- a/pegasus/src/Clients/cimcli/CIMCLIOperations.cpp
+++ b/pegasus/src/Clients/cimcli/CIMCLIOperations.cpp
@@ -381,7 +381,7 @@ OperationExampleEntry OperationExamples[] = {
 
     // Create Class Not Supported
     {"Clients.cimcli.CIMCLIClient.OPERATION_NOT_SUPPORTED",
-    "Operation Not supported..\n",
+    "Create Class Operation Not supported..\n",
     "Clients.cimcli.CIMCLIClient.OPERATION_NOT_SUPPORTED",
     "\n"},
 
@@ -424,13 +424,13 @@ OperationExampleEntry OperationExamples[] = {
     {"Clients.cimcli.CIMCLIClient.GQ_COMMAND_EXAMPLE",
     "cimcli gq Association\n"
         "    -- Get the qualifier named Association in mof output\n"
-        "       in the default namespace (normally root/cimv2)",
+        "       in the default namespace (normally root/cimv2)\n",
     "Clients.cimcli.CIMCLIClient.GQ_COMMAND_OPTIONS",
     "    -n\n"},
 
     // setQualifier
     {"Clients.cimcli.CIMCLIClient.OPERATION_NOT_SUPPORTED",
-    "Operation Not supported..\n",
+    "setQualifier Operation Not supported..\n",
     "Clients.cimcli.CIMCLIClient.OPERATION_NOT_SUPPORTED",
     "\n"},
 

--- a/pegasus/src/Providers/TestProviders/CLITestProvider/tests/Makefile
+++ b/pegasus/src/Providers/TestProviders/CLITestProvider/tests/Makefile
@@ -710,6 +710,9 @@ testInvokeMethod:
 	    InParam1="test/TestProvider:class.key1=\"aaa\",key2=0" \
 	    InParam2="test/TestProvider:class.key1=\\\"aaa01\\\"\,key2=1","test/TestProvider:class.key1=\\\"aaa02\\\"\,key2=2" \
 	     -x >>$(RESULTFILE)
+
+	@cimcli im Test_CLITestProviderClass -n "$(PROVIDERNS)" \
+	    delayedMethodResponse delayInSeconds=2 >>$(RESULTFILE)
 	    
 	@$(ECHO) +++++ Test invoke method Passed.
 

--- a/pegasus/src/Providers/TestProviders/CLITestProvider/tests/helpresult.master
+++ b/pegasus/src/Providers/TestProviders/CLITestProvider/tests/helpresult.master
@@ -248,7 +248,7 @@ or
     -- Delete Instance of class TST_Persion with object path
        TST_Person.name="Mike" using object path input format
 
-Operation Not supported..
+Create Class Operation Not supported..
 
 cimcli mi -n test/TestProvider TST_Person.Id=\"Mike\" SSN=444
     -- Modifies the Instance if it exists using rules of DMTF 
@@ -267,7 +267,8 @@ cimcli sp -n test/TestProvider TST_Person.Id=\"Mike\" SSN=333
 cimcli gq Association
     -- Get the qualifier named Association in mof output
        in the default namespace (normally root/cimv2)
-Operation Not supported..
+
+setQualifier Operation Not supported..
 
 cimcli eq -n test/TestProvider
     -- Enumerate Qualifiers of namespace test/TestProvider

--- a/pegasus/src/Providers/TestProviders/CLITestProvider/tests/result.master
+++ b/pegasus/src/Providers/TestProviders/CLITestProvider/tests/result.master
@@ -130,6 +130,18 @@ class Test_CLITestProviderClass
             "1 if same state.  Else return 2, as error " ), 
         static]
     uint32 debugMode(boolean newState);
+    
+        [Description ( "Method to execute a delayed response. When called "
+            "the provider must return a response but delayed by the "
+            "parameter in the call. If the input parameter is not provided, "
+            "the server must return a normal response immediatly." ), 
+            
+        static]
+    uint32 delayedMethodResponse([in, 
+    out, 
+    Description ( "Delay in seconds. The server must delay the response "
+        "to this invoke for the time defined by this parameter and then "
+        "do a normal response" )] uint32 delayInSeconds);
 };
 
 // ===================================================
@@ -1957,6 +1969,8 @@ Return Value= <VALUE>0</VALUE>
 </VALUE.REFARRAY>
 </PARAMVALUE>
 
+Return Value= 0
+delayInSeconds=2
 10. +++++ testPropertyListOptions
 
 // ===================================================
@@ -2364,6 +2378,7 @@ class Test_CLITestProviderClass
     uint32 resetProviderParameters();
     uint32 reset();
     uint32 debugMode(boolean newState);
+    uint32 delayedMethodResponse(uint32 delayInSeconds);
 };
 1 associatorNames
 //ChangedHostName/test/TestProvider:Test_CLITestProviderClass

--- a/pegasus/src/Providers/TestProviders/IndicationTestProvider/IndicationTestProvider.cpp
+++ b/pegasus/src/Providers/TestProviders/IndicationTestProvider/IndicationTestProvider.cpp
@@ -405,8 +405,10 @@ void IndicationTestProvider::invokeMethod(
     else
     {
          handler.deliver( CIMValue( 1 ) );
-         PEGASUS_STD(cout) << "Provider is not enabled." <<
-             PEGASUS_STD(endl);
+         PEGASUS_STD(cout) << "IndicationTestProvider not enabled for class "
+             << objectReference.getClassName().getString()
+             << "."
+             << PEGASUS_STD(endl);
     }
 
     handler.complete();

--- a/pegasus/src/Providers/TestProviders/Load/CLITestProvider.mof
+++ b/pegasus/src/Providers/TestProviders/Load/CLITestProvider.mof
@@ -178,6 +178,18 @@ class Test_CLITestProviderClass
        "Parameter is new state. Returns 0 if state changed. Rtn 1 if "
        "same state.  Else return 2, as error "), static ]
    uint32 debugMode(Boolean newState);
+
+       [Description ("Method to execute a delayed response. "
+       "When called the provider must return a response but delayed "
+       "by the parameter in the call. If the input parameter is not "
+       "provided, the server must return a normal response immediatly."),
+       static ]
+   uint32 delayedMethodResponse(
+       [in,out, Description("Delay in seconds. The server must delay "
+       "the response to this invoke for the time defined by this "
+       "parameter and then do a normal response")]
+       uint32 delayInSeconds
+       );
 };
 
 [Association, Version("1.0.0"), Description (

--- a/pegasus/src/Providers/TestProviders/Load/CLITestProviderR.mof
+++ b/pegasus/src/Providers/TestProviders/Load/CLITestProviderR.mof
@@ -60,6 +60,7 @@ instance of PG_ProviderCapabilities
                          "setProviderParameters",
 			 "resetProviderParameters",
 			 "debugMode",
+			 "delayedMethodResponse",
 			 "reset" };
 };
 


### PR DESCRIPTION
Implements a method in the provider CLITestProvider that will delay its response by the time defined in the method.

This can be used to test client delayed response handling.