### PR TITLE
Add step to execute make world in root with sudo

### DIFF
--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -127,7 +127,22 @@ jobs:
             export
             echo "Display env variables end"
 
-      - name: Build OpenPegasus non-privileged
+      #- name: Build OpenPegasus non-privileged
+        #shell: bash
+        #run: |
+            #echo "show export"
+            #export
+            #echo "End show export"
+            #echo "Start build"
+            #cd pegasus
+            #make world
+            #echo "End build Step"
+        #env:
+            ## env variables required for non-root minimal build and test
+            #PEGASUS_DISABLE_PROV_USERCTXT: true
+            #PEGASUS_DISABLE_PRIVILEGED_TESTS: true
+
+      - name: Build OpenPegasus privileged
         shell: bash
         run: |
             echo "show export"
@@ -135,12 +150,14 @@ jobs:
             echo "End show export"
             echo "Start build"
             cd pegasus
-            make world
+            # Execute as sudo with env variables  and the bin added to path
+            sudo "PATH=$PATH:$PEGASUS_HOME/bin" \
+                --preserve-env=PEGASUS_ROOT,PEGASUS_HOME,PEGASUS_PLATFORM,PEGASUS_HAS_SSL \
+                make -f $PWD/Makefile world
             echo "End build Step"
         env:
             # env variables required for non-root minimal build and test
-            PEGASUS_DISABLE_PROV_USERCTXT: true
-            PEGASUS_DISABLE_PRIVILEGED_TESTS: true
+            PEGASUS_HAS_SSL: true
 
 
       #- name: Test

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,17 @@ Enhancements
 
 cleanup
 
+* Add use of github actions to test capability.  Tests are executed on each
+  push.  The tests are currently limited because each execution of the test
+  suite currently takes about an hour.
+
+* Update a number of tests that apparently were not executed because we were
+  not executing tests in the the user non-privileged.  This includes tests in
+  Clients/wbemexec and TestProviders/CLIProviderTests.
+
+
+
+
 
 openpegasus 14.2 - Release
 --------------------------

--- a/pegasus/src/Pegasus/General/tests/Stopwatch/TestStopwatch.cpp
+++ b/pegasus/src/Pegasus/General/tests/Stopwatch/TestStopwatch.cpp
@@ -59,7 +59,9 @@ int main(int, char** argv)
         sw.printElapsed();
     }
 
-    PEGASUS_TEST_ASSERT((elapsed >= 4.5) && (elapsed <= 5.5));
+    // KS. Modified the minimum from 4.5 to 4.0 because in virtual envrionments
+    // the the sleep occasionally produces times lest than 4.5. KS Feb 2022
+    PEGASUS_TEST_ASSERT((elapsed >= 4.0) && (elapsed <= 5.5));
 
     cout << argv[0] << " +++++ passed all tests" << endl;
 

--- a/pegasus/src/Providers/TestProviders/CLITestProvider/tests/helpresult.master.ssl
+++ b/pegasus/src/Providers/TestProviders/CLITestProvider/tests/helpresult.master.ssl
@@ -260,7 +260,7 @@ or
     -- Delete Instance of class TST_Persion with object path
        TST_Person.name="Mike" using object path input format
 
-Operation Not supported..
+Create Class Operation Not supported..
 
 cimcli mi -n test/TestProvider TST_Person.Id=\"Mike\" SSN=444
     -- Modifies the Instance if it exists using rules of DMTF 
@@ -279,7 +279,8 @@ cimcli sp -n test/TestProvider TST_Person.Id=\"Mike\" SSN=333
 cimcli gq Association
     -- Get the qualifier named Association in mof output
        in the default namespace (normally root/cimv2)
-Operation Not supported..
+
+setQualifier Operation Not supported..
 
 cimcli eq -n test/TestProvider
     -- Enumerate Qualifiers of namespace test/TestProvider

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,8 @@
 # Test of a fixed configure as bash shell
 echo $PWD
 
-export ROOT=.
+# Set Root to the current directory.
+export ROOT=$PWD
 export PEGASUS_ROOT=$ROOT/pegasus
 export PEGASUS_HOME=$ROOT/home
 export PATH=$PEGASUS_HOME/bin:$PATH


### PR DESCRIPTION
Created a new step that executes the test suite in privileged mode and, for now, disables the test step that builds non-privileged 