### PR TITLE
Ks/#82 indicationsub property

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -24,8 +24,8 @@ Bugs
   when getInstance and EnumerateInstance called in IndicationServices.
   This property was left empty before meaning that the value of the
   paths was not equal to the value of the corresponding property
-  components because the properties had left the sysname key of the
-  Filter and Handler cim objects empty.  (See issue #82)
+  components because the missing key property.   Also reorganized
+  some code to simplify logic. (See issue #82)
 
 
 Enhancements

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,6 +20,13 @@ Status: Development
 
 Bugs
 
+* Add code to set the system name into Indication subscription instances
+  when getInstance and EnumerateInstance called in IndicationServices.
+  This property was left empty before meaning that the value of the
+  paths was not equal to the value of the corresponding property
+  components because the properties had left the sysname key of the
+  Filter and Handler cim objects empty.  (See issue #82)
+
 
 Enhancements
 

--- a/pegasus/src/Pegasus/IndicationService/IndicationService.h
+++ b/pegasus/src/Pegasus/IndicationService/IndicationService.h
@@ -186,6 +186,19 @@ public:
      */
     static void _setSystemName(CIMInstance& instance, const String& sysname);
 
+    /** Replaces value of SystemName key in reference CIM Property with 
+        name in instance of CIM_IndicationSubscription
+
+        Used for Subscription object paths to set sysname in the
+        Handler and Filter reference properties
+
+        @param   instance             instance containing property
+        @param   propertyName         name of proerty to change
+        @param   sysname              system name to set
+     */
+    static void _setSystemName(CIMInstance& instance,
+                               const CIMName& propertyName,
+                               const String& sysname);
 
 private:
 

--- a/pegasus/src/Pegasus/IndicationService/IndicationService.h
+++ b/pegasus/src/Pegasus/IndicationService/IndicationService.h
@@ -138,14 +138,27 @@ public:
         CIMInstance& instance,
         const String& sysname);
 
+    /**  TODO TODO eliminate.
+        Sets property with name SystemName to sysname if existant. If
+        property does not exist on instance, adds it.
+        Should be used for instances of classes Filter, Handler only
+        Does not change the objectPath of the instance !!!
+
+        @param   instance              instance to set property on
+        @param   sysname               system name to set
+    static void _setSystemName(
+        CIMInstance& instance,
+        const String& sysname);
+     */
+
     /**
-        Sets key binding with name SystemName to string if existant. Should be
+        Sets key binding with name SystemName to object path if exists. Should be
         used with Handler and Filter object paths only
 
         @param   objPath              object path to change keybinding on
         @param   sysname              system name to set
      */
-    static void _setSystemNameInHandlerFilter(
+    static void _setSystemNameInHandlerFilterPath(
         CIMObjectPath& objPath,
         const String& sysname);
 
@@ -161,33 +174,56 @@ public:
         Sets key binding with name SystemName in the two keybinding references
         Filter and Handler of a Subscription object path
 
-        @param   objPath              object path to change SystemNames on
+        @param   String               string to change SystemNames on
+        @param   sysname              system name to set
+        @param   setPathFlag          Boolean where true requests that
+                                      method set the sysname in the path
+     */
+    static void _setSystemNameInSubscription(
+        CIMInstance& instance,
+        const String& sysname,
+        Boolean setPathFlag);
+
+    /** Replaces value in all components of indication subscription
+        response object including path and reference properties.
+
+        @param   instance              instance to change SystemNames on
         @param   sysname              system name to set
      */
-    static void _setSubscriptionSystemName(
+    static void _setSystemNameInObjectPath(
+        CIMObjectPath& objPath,
+        const String& sysname);
+        
+    /** Replaces value indication subscription
+        object path tp include the system math
+
+        @param   objPath              objectPath to change SystemNames on
+        @param   sysname              system name to set
+     */        
+    static void _setSystemNameinSubscriptionPath(
         CIMObjectPath& objPath,
         const String& sysname);
 
-    /** Replaces value in all occurences of SystemName key with String sysname
-        used for Handler, Filter and Subscription object paths
+    /** Replaces value in provided object path with system name
 
-        @param   objPath              object path to change SystemNames on
-        @param   sysname              system name to set
-     */
-    static void _setSystemName(CIMObjectPath& objPath, const String& sysname);
+        Used for Handler, Filter and Subscription object paths.
 
-    /** Replaces value in all occurences of SystemName key and SystemName
-        property with String sysname
-
-        Used for Handler, Filter and Subscription object paths
+        Sets system name in properties as required by class and
+        conditionally sets system name in path component. Not
+        all instances include the path component (i.e. instances
+        retrieved with GetInstance do not include path)
 
         @param   instance             instance to change
         @param   sysname              system name to set
+        @param   setPathFlag          Boolean defines existence
+                                      of object path
      */
-    static void _setSystemName(CIMInstance& instance, const String& sysname);
+    static void _setSystemName(CIMInstance& instance,
+                               const String& sysname,
+                               Boolean setPathFlag);
 
-    /** Replaces value of SystemName key in reference CIM Property with 
-        name in instance of CIM_IndicationSubscription
+    /** Replaces value of SystemName key in reference CIM Property
+        define by propertyName with sysname.
 
         Used for Subscription object paths to set sysname in the
         Handler and Filter reference properties
@@ -196,9 +232,30 @@ public:
         @param   propertyName         name of proerty to change
         @param   sysname              system name to set
      */
-    static void _setSystemName(CIMInstance& instance,
+    static void _setSystemNameInProperty(CIMInstance& instance,
                                const CIMName& propertyName,
                                const String& sysname);
+
+    /** If the instance is an IndicationSubscription instance return
+        true, otherwise return false.
+        
+        @param instance              instance to be tested. 
+     */
+    static Boolean _isSubscription(const CIMInstance& instance);
+    
+    /** If the object path is an IndicationSubscription cim instance 
+        return true, otherwise return false.
+        
+        @param instance              instance to be tested. 
+     */
+    static Boolean _isSubscription(const CIMObjectPath& objPath);
+
+    /** If the CIMName is an IndicationSubscription className 
+        return true, otherwise return false.
+        
+        @param className              CIMName className to be tested. 
+     */
+    static Boolean _isSubscription(const CIMName& className);
 
 private:
 

--- a/pegasus/src/Pegasus/IndicationService/tests/IndicationService/TestIndicationService.cpp
+++ b/pegasus/src/Pegasus/IndicationService/tests/IndicationService/TestIndicationService.cpp
@@ -67,12 +67,12 @@ void test_setSystemNameInHandlerFilter()
 
     source.set(fullSourcePath);
     PEGASUS_TEST_ASSERT(source != emptyTarget);
-    IndicationService::_setSystemNameInHandlerFilter(source,String::EMPTY);
+    IndicationService::_setSystemNameInHandlerFilterPath(source,String::EMPTY);
     PEGASUS_TEST_ASSERT(source == emptyTarget);
 
     source.set(fullSourcePath);
     PEGASUS_TEST_ASSERT(source != setTarget);
-    IndicationService::_setSystemNameInHandlerFilter(source,"TestSys");
+    IndicationService::_setSystemNameInHandlerFilterPath(source,"TestSys");
     PEGASUS_TEST_ASSERT(source == setTarget);
 }
 
@@ -173,11 +173,145 @@ void test_setSystemNameInHandlerFilterReference()
     PEGASUS_TEST_ASSERT(fullSourcePath == fullSetTargetPath);
 }
 
+CIMObjectPath _buildFilterOrHandlerPath
+    (const CIMName & className,
+     const String & name,
+     const String & host,
+     const CIMNamespaceName & namespaceName = CIMNamespaceName())
+{
+    CIMObjectPath path;
+
+    Array <CIMKeyBinding> keyBindings;
+    keyBindings.append (CIMKeyBinding ("SystemCreationClassName",
+        System::getSystemCreationClassName(), CIMKeyBinding::STRING));
+    keyBindings.append (CIMKeyBinding ("SystemName",
+        System::getFullyQualifiedHostName(), CIMKeyBinding::STRING));
+    keyBindings.append (CIMKeyBinding ("CreationClassName",
+        className.getString(), CIMKeyBinding::STRING));
+    keyBindings.append (CIMKeyBinding ("Name", name, CIMKeyBinding::STRING));
+    path.setClassName (className);
+    path.setKeyBindings (keyBindings);
+    path.setNameSpace (namespaceName);
+    path.setHost (host);
+
+    return path;
+}
+
+CIMObjectPath _buildSubscriptionPath
+    (const String & filterName,
+     const CIMName & handlerClass,
+     const String & handlerName,
+     const String & filterHost,
+     const String & handlerHost,
+     const CIMNamespaceName & filterNS,
+     const CIMNamespaceName & handlerNS)
+{
+    CIMObjectPath filterPath = _buildFilterOrHandlerPath
+        (PEGASUS_CLASSNAME_INDFILTER, filterName, filterHost, filterNS);
+
+    CIMObjectPath handlerPath = _buildFilterOrHandlerPath (handlerClass,
+        handlerName, handlerHost, handlerNS);
+
+    Array<CIMKeyBinding> subscriptionKeyBindings;
+    subscriptionKeyBindings.append (CIMKeyBinding ("Filter",
+        filterPath.toString(), CIMKeyBinding::REFERENCE));
+    subscriptionKeyBindings.append (CIMKeyBinding ("Handler",
+        handlerPath.toString(), CIMKeyBinding::REFERENCE));
+    CIMObjectPath subscriptionPath ("", CIMNamespaceName(),
+        PEGASUS_CLASSNAME_INDSUBSCRIPTION, subscriptionKeyBindings);
+
+    return subscriptionPath;
+}
+
+// Build subscription with empty 
+CIMObjectPath _buildSubscriptionPath
+    (const String & filterName,
+     const CIMName & handlerClass,
+     const String & handlerName)
+{
+    return _buildSubscriptionPath(filterName, handlerClass, handlerName,
+        String::EMPTY, String::EMPTY, CIMNamespaceName(), CIMNamespaceName());
+}
+
+CIMInstance _buildSubscriptionInstance
+    (const CIMObjectPath & filterPath,
+     const CIMName & handlerClass,
+     const CIMObjectPath & handlerPath)
+{
+    CIMInstance subscriptionInstance (PEGASUS_CLASSNAME_INDSUBSCRIPTION);
+
+    CIMObjectPath path = _buildSubscriptionPath ("Filter01",
+        PEGASUS_CLASSNAME_INDHANDLER_CIMXML, "Handler01");
+    subscriptionInstance.setPath (path);
+
+    subscriptionInstance.addProperty (CIMProperty (CIMName ("Filter"),
+        filterPath, 0, PEGASUS_CLASSNAME_INDFILTER));
+    subscriptionInstance.addProperty (CIMProperty (CIMName ("Handler"),
+        handlerPath, 0, handlerClass));
+
+    return subscriptionInstance;
+}
+
+
+void test_isSubscription()
+{
+    CIMObjectPath filterPath = _buildFilterOrHandlerPath(
+        PEGASUS_CLASSNAME_INDFILTER,
+        "Filter1",
+        System::getFullyQualifiedHostName(),
+        PEGASUS_NAMESPACENAME_INTEROP);
+
+    CIMObjectPath handlerPath = _buildFilterOrHandlerPath(
+        PEGASUS_CLASSNAME_INDHANDLER_CIMXML,
+        "handler1",
+        System::getFullyQualifiedHostName(),
+        PEGASUS_NAMESPACENAME_INTEROP);        
+    
+    PEGASUS_TEST_ASSERT(IndicationService::_isSubscription(filterPath) == false);
+    PEGASUS_TEST_ASSERT(IndicationService::_isSubscription(handlerPath) == false);
+    /* TODO, Not finished Superceeded by tests in Subscription
+    CIMInstance subscription = _buildSubscriptionInstance(
+        filterPath,
+        PEGASUS_CLASSNAME_INDHANDLER_CIMXML,
+        handlerPath);
+
+    PEGASUS_TEST_ASSERT(IndicationService::_isSubscription(subscription) == true);
+    */
+}
+
+void test_setSystemNameInSubscription()
+{
+    CIMObjectPath filterPath = _buildFilterOrHandlerPath(
+        PEGASUS_CLASSNAME_INDFILTER,
+        "Filter1",
+        String::EMPTY,
+        PEGASUS_NAMESPACENAME_INTEROP);
+
+    CIMObjectPath handlerPath = _buildFilterOrHandlerPath(
+        PEGASUS_CLASSNAME_INDHANDLER_CIMXML,
+        "handler1",
+        String::EMPTY,
+        PEGASUS_NAMESPACENAME_INTEROP);
+        
+    CIMInstance subscription = _buildSubscriptionInstance(
+        filterPath,
+        PEGASUS_CLASSNAME_INDHANDLER_CIMXML,
+        handlerPath);
+
+    IndicationService::_setSystemNameInSubscription(
+        subscription, System::getFullyQualifiedHostName(),
+        true);
+
+    // TODO test result
+    
+}
+
 int main()
 {
     test_setSystemNameInHandlerFilter();
     test_setOrAddSystemNameInHandlerFilter();
     test_setSystemNameInHandlerFilterReference();
+    test_setSystemNameInSubscription();
 
     return 0;
 }

--- a/pegasus/src/Pegasus/IndicationService/tests/Subscription/Subscription.cpp
+++ b/pegasus/src/Pegasus/IndicationService/tests/Subscription/Subscription.cpp
@@ -1235,6 +1235,7 @@ void _valid (CIMClient & client, String& qlang)
     _checkUint64Property (retrievedInstance, "RepeatNotificationInterval", 60);
     _checkUint64Property (retrievedInstance, "RepeatNotificationGap", 30);
     _checkUint16Property (retrievedInstance, "RepeatNotificationCount", 5);
+    // TODO test Handler and Filter reference properties against path
 
     //
     //  Enumerate subscriptions

--- a/pegasus/src/Pegasus/IndicationService/tests/Subscription/Subscription.cpp
+++ b/pegasus/src/Pegasus/IndicationService/tests/Subscription/Subscription.cpp
@@ -471,6 +471,45 @@ void _checkStringProperty
     }
 }
 
+void _checkReferenceProperty
+    (CIMInstance & instance,
+     const String & name,
+     const CIMObjectPath &value,
+     Boolean null = false)
+{
+    Uint32 pos = instance.findProperty (name);
+    PEGASUS_TEST_ASSERT (pos != PEG_NOT_FOUND);
+
+    CIMProperty theProperty = instance.getProperty (pos);
+    CIMValue theValue = theProperty.getValue();
+
+    PEGASUS_TEST_ASSERT (theValue.getType() == CIMTYPE_REFERENCE);
+    PEGASUS_TEST_ASSERT (!theValue.isArray());
+    if (null)
+    {
+        PEGASUS_TEST_ASSERT (theValue.isNull());
+    }
+    else
+    {
+        PEGASUS_TEST_ASSERT (!theValue.isNull());
+        CIMObjectPath result;
+        theValue.get (result);
+
+        if (verbose)
+        {
+            if (result != value)
+            {
+                cerr << "Property value comparison failed.  ";
+                cerr << "Expected " << value.toString() << "; ";
+                cerr << "Actual property value was " << result.toString() << "." << endl;
+            }         
+        }
+
+        PEGASUS_TEST_ASSERT (result == value);
+    }
+}
+
+
 void _checkUint16Property
     (CIMInstance & instance,
      const String & name,
@@ -724,6 +763,8 @@ void _register (CIMClient & client)
 void _valid (CIMClient & client, String& qlang)
 {
     CIMObjectPath path;
+    CIMObjectPath filterPath;
+    CIMObjectPath handlerPath;
     String query;
     CIMInstance retrievedInstance;
     Array <CIMInstance> instances;
@@ -1218,6 +1259,7 @@ void _valid (CIMClient & client, String& qlang)
 
     _checkSubscriptionPath (path, "Filter01",
         PEGASUS_CLASSNAME_INDHANDLER_CIMXML, "Handler01");
+        
     retrievedInstance =
         client.getInstance (PEGASUS_NAMESPACENAME_INTEROP, path);
     _checkUint16Property (retrievedInstance, "OnFatalErrorPolicy", 2);
@@ -1235,8 +1277,16 @@ void _valid (CIMClient & client, String& qlang)
     _checkUint64Property (retrievedInstance, "RepeatNotificationInterval", 60);
     _checkUint64Property (retrievedInstance, "RepeatNotificationGap", 30);
     _checkUint16Property (retrievedInstance, "RepeatNotificationCount", 5);
-    // TODO test Handler and Filter reference properties against path
 
+    // Validate Handler and Filter reference properties against path
+    filterPath = _buildFilterOrHandlerPath(PEGASUS_CLASSNAME_INDFILTER,
+        "Filter01", String::EMPTY, CIMNamespaceName());
+    _checkReferenceProperty (retrievedInstance, "Filter", filterPath);
+
+    handlerPath = _buildFilterOrHandlerPath (PEGASUS_CLASSNAME_INDHANDLER_CIMXML,
+        "Handler01", String::EMPTY, CIMNamespaceName());
+     _checkReferenceProperty (retrievedInstance, "Handler", handlerPath);
+        
     //
     //  Enumerate subscriptions
     //
@@ -1265,6 +1315,15 @@ void _valid (CIMClient & client, String& qlang)
     _checkSubscriptionPath (path, "Filter01",
         PEGASUS_CLASSNAME_INDHANDLER_CIMXML, "Handler01");
 
+    // Validate Handler and Filter reference properties against path
+    filterPath = _buildFilterOrHandlerPath(PEGASUS_CLASSNAME_INDFILTER,
+        "Filter01", String::EMPTY, CIMNamespaceName());
+    _checkReferenceProperty (retrievedInstance, "Filter", filterPath);
+
+    handlerPath = _buildFilterOrHandlerPath (PEGASUS_CLASSNAME_INDHANDLER_CIMXML,
+        "Handler01", String::EMPTY, CIMNamespaceName());
+    _checkReferenceProperty (retrievedInstance, "Handler", handlerPath);
+
     CIMInstance subscription02 = _buildSubscriptionInstance
         (_buildFilterOrHandlerPath (PEGASUS_CLASSNAME_INDFILTER, "Filter02"),
         PEGASUS_CLASSNAME_INDHANDLER_CIMXML,
@@ -1280,6 +1339,15 @@ void _valid (CIMClient & client, String& qlang)
     _checkUint16Property (retrievedInstance, "OnFatalErrorPolicy", 2);
     _checkUint16Property (retrievedInstance, "SubscriptionState", 2);
     _checkUint16Property (retrievedInstance, "RepeatNotificationPolicy", 2);
+
+    // Validate Handler and Filter reference properties against path
+    filterPath = _buildFilterOrHandlerPath(PEGASUS_CLASSNAME_INDFILTER,
+        "Filter02", String::EMPTY, CIMNamespaceName());
+    _checkReferenceProperty (retrievedInstance, "Filter", filterPath);
+
+    handlerPath = _buildFilterOrHandlerPath (PEGASUS_CLASSNAME_INDHANDLER_CIMXML,
+        "Handler01", String::EMPTY, CIMNamespaceName());
+     _checkReferenceProperty (retrievedInstance, "Handler", handlerPath);
 
     CIMInstance subscription03 = _buildSubscriptionInstance
         (_buildFilterOrHandlerPath (PEGASUS_CLASSNAME_INDFILTER, "Filter03"),
@@ -1297,6 +1365,15 @@ void _valid (CIMClient & client, String& qlang)
     _checkUint16Property (retrievedInstance, "SubscriptionState", 2);
     _checkUint16Property (retrievedInstance, "RepeatNotificationPolicy", 2);
 
+    // Validate Handler and Filter reference properties against path
+    filterPath = _buildFilterOrHandlerPath(PEGASUS_CLASSNAME_INDFILTER,
+        "Filter03", String::EMPTY, CIMNamespaceName());
+    _checkReferenceProperty (retrievedInstance, "Filter", filterPath);
+
+    handlerPath = _buildFilterOrHandlerPath (PEGASUS_CLASSNAME_INDHANDLER_CIMXML,
+        "Handler01", String::EMPTY, CIMNamespaceName());
+     _checkReferenceProperty (retrievedInstance, "Handler", handlerPath);
+
     CIMInstance subscription04 = _buildSubscriptionInstance
         (_buildFilterOrHandlerPath (PEGASUS_CLASSNAME_INDFILTER, "Filter04"),
         PEGASUS_CLASSNAME_INDHANDLER_CIMXML,
@@ -1312,6 +1389,15 @@ void _valid (CIMClient & client, String& qlang)
     _checkUint16Property (retrievedInstance, "OnFatalErrorPolicy", 2);
     _checkUint16Property (retrievedInstance, "SubscriptionState", 2);
     _checkUint16Property (retrievedInstance, "RepeatNotificationPolicy", 2);
+
+    // Validate Handler and Filter reference properties against path
+    filterPath = _buildFilterOrHandlerPath(PEGASUS_CLASSNAME_INDFILTER,
+        "Filter04", String::EMPTY, CIMNamespaceName());
+    _checkReferenceProperty (retrievedInstance, "Filter", filterPath);
+
+    handlerPath = _buildFilterOrHandlerPath (PEGASUS_CLASSNAME_INDHANDLER_CIMXML,
+        "Handler01", String::EMPTY, CIMNamespaceName());
+     _checkReferenceProperty (retrievedInstance, "Handler", handlerPath);
 
     CIMInstance subscription05 = _buildSubscriptionInstance
         (_buildFilterOrHandlerPath (PEGASUS_CLASSNAME_INDFILTER, "Filter05"),
@@ -1329,6 +1415,15 @@ void _valid (CIMClient & client, String& qlang)
     _checkUint16Property (retrievedInstance, "SubscriptionState", 2);
     _checkUint16Property (retrievedInstance, "RepeatNotificationPolicy", 2);
 
+    // Validate Handler and Filter reference properties against path
+    filterPath = _buildFilterOrHandlerPath(PEGASUS_CLASSNAME_INDFILTER,
+        "Filter05", String::EMPTY, CIMNamespaceName());
+    _checkReferenceProperty (retrievedInstance, "Filter", filterPath);
+
+    handlerPath = _buildFilterOrHandlerPath (PEGASUS_CLASSNAME_INDHANDLER_CIMXML,
+        "Handler01", String::EMPTY, CIMNamespaceName());
+     _checkReferenceProperty (retrievedInstance, "Handler", handlerPath);
+
     CIMInstance subscription06 = _buildSubscriptionInstance
         (_buildFilterOrHandlerPath (PEGASUS_CLASSNAME_INDFILTER, "Filter06"),
         PEGASUS_CLASSNAME_INDHANDLER_CIMXML,
@@ -1345,9 +1440,21 @@ void _valid (CIMClient & client, String& qlang)
     _checkUint16Property (retrievedInstance, "SubscriptionState", 2);
     _checkUint16Property (retrievedInstance, "RepeatNotificationPolicy", 2);
 
+    // Validate Handler and Filter reference properties against path
+    filterPath = _buildFilterOrHandlerPath(PEGASUS_CLASSNAME_INDFILTER,
+        "Filter06", String::EMPTY, CIMNamespaceName());
+    _checkReferenceProperty (retrievedInstance, "Filter", filterPath);
+
+    handlerPath = _buildFilterOrHandlerPath (PEGASUS_CLASSNAME_INDHANDLER_CIMXML,
+        "Handler01", String::EMPTY, CIMNamespaceName());
+     _checkReferenceProperty (retrievedInstance, "Handler", handlerPath);
+
     //
     //  Create subscription with transient handler
     //
+
+    // NOTE: Subscription filter and handler property test not included
+    // for some of tthe following tests
     CIMInstance subscription07 = _buildSubscriptionInstance
         (_buildFilterOrHandlerPath (PEGASUS_CLASSNAME_INDFILTER, "Filter01"),
         PEGASUS_CLASSNAME_INDHANDLER_CIMXML,
@@ -1363,6 +1470,15 @@ void _valid (CIMClient & client, String& qlang)
     _checkUint16Property (retrievedInstance, "OnFatalErrorPolicy", 2);
     _checkUint16Property (retrievedInstance, "SubscriptionState", 2);
     _checkUint16Property (retrievedInstance, "RepeatNotificationPolicy", 2);
+
+    // Validate Handler and Filter reference properties against path
+    filterPath = _buildFilterOrHandlerPath(PEGASUS_CLASSNAME_INDFILTER,
+        "Filter01", String::EMPTY, CIMNamespaceName());
+    _checkReferenceProperty (retrievedInstance, "Filter", filterPath);
+
+    handlerPath = _buildFilterOrHandlerPath (PEGASUS_CLASSNAME_INDHANDLER_CIMXML,
+        "Handler02", String::EMPTY, CIMNamespaceName());
+     _checkReferenceProperty (retrievedInstance, "Handler", handlerPath);
 
     //
     //  Delete transient handler - referencing subscription must be deleted

--- a/setup.sh
+++ b/setup.sh
@@ -1,15 +1,18 @@
 # Test of a fixed configure as bash shell
 echo $PWD
 
+export PEGASUS_PLATFORM=LINUX_X86_64_GNU
+
 # Set Root to the current directory.
 export ROOT=$PWD
 export PEGASUS_ROOT=$ROOT/pegasus
 export PEGASUS_HOME=$ROOT/home
 export PATH=$PEGASUS_HOME/bin:$PATH
-mkdir $PEGASUS_HOME
+mkdir $PEGASUS_HOME -p
 export LD_LIBRARY_PATH=$PEGASUS_HOME/lib64:
 
-export PEGASUS_PLATFORM=LINUX_X86_64_GNU
+
+
 
 # Storage mode of the CIM repository created on initial build
 # This may be modified using cimconfig.

--- a/setup.sh
+++ b/setup.sh
@@ -11,9 +11,6 @@ export PATH=$PEGASUS_HOME/bin:$PATH
 mkdir $PEGASUS_HOME -p
 export LD_LIBRARY_PATH=$PEGASUS_HOME/lib64:
 
-
-
-
 # Storage mode of the CIM repository created on initial build
 # This may be modified using cimconfig.
 # The default if this is not uses is XML
@@ -39,3 +36,5 @@ export PEGASUS_PAM_AUTHENTICATION=true
 export PEGASUS_USE_PAM_STANDALONE_PROC=false
 export PEGASUS_ENABLE_CMPI_PROVIDER_MANAGER=true
 export PEGASUS_PLATFORM_FOR_32BIT_PROVIDER_SUPPORT=LINUX_X86_64_GNU
+
+export | grep PEGASUS


### PR DESCRIPTION
fixes to complete indication subscription get and enumerate instances. 

This fixes the issue where OpenPegasus was returning incomplete CIM_IndicationSubscription instances for GetInstance and EnumerateInstance (The paths in the Handler and Filter reference were incomplete).  The CIMObjectPath component was always correct.

This change  includes

1. Fix so the system name property does appear in the instance properties as well as in the paths so that for filters, handlers, and subscriptions, the user gets instances that match their properties.
2. Rewrite of the methods around setting system name to make them more logical
3. Some other rewrites in IndicationService to reduce the duplication of code.
4. Addition to tests to test the new methods and also test that the client gets the correct information. These were minor changes.