### PR TITLE
Release branch for Pegasus version 2.14.4

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -7,11 +7,11 @@
 
 Status: **Released**
 
-Released: 22 August 2023
+Released: 27 August 2023
 
 Start Branch: main
 
-This release was based on the main branch, since there is no 2.14.0 branch
+This release is based on the main branch, since there is no 2.14.0 branch
 to serve as the base (We started this repository from OpenPegasus 2.14.1)
 
 


### PR DESCRIPTION
This release is created from the main branch and not from stable 2.14.x branch.  See changes.rst for more information and for information on what is in this branch