### PR TITLE
ci: set minimum token permissions for the GITHUB_TOKEN

### DIFF
--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -20,6 +20,9 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or
 # in parallel
 
+permissions:
+  contents: read
+
 jobs:
 
   # This workflow contains a single job called "build"


### PR DESCRIPTION
I am pleased to submit this pull request implementing GitHub-recommended security practices by configuring the GITHUB_TOKEN permissions using the StepSecurity. This adjustment strictly adheres to the principle of least privilege outlined in the [GitHub official documentation](https://docs.github.com/en/actions/security-guides/automatic-token-authentication), ensuring enhanced workflow security for the OpenPegasus project.